### PR TITLE
Add Windows ARM64 build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,12 +208,12 @@ Build instructions
 ### Windows
 1.  Get [Visual Studio 2019][8] - you need "Desktop development with C++" module only
 2.  Install [CMake][9]
-3.  Install latest Qt v5 (64-bit) from [Qt website][10]. You only need "Qt 5.13.2 Prebuilt Components for MSVC 2017 64-bit" (MSVC 2017 64-bit). Later steps assume you install it in c:\Qt
+3.  Install Qt v5 for your target architecture from [Qt website][10]. For x64 builds "Qt 5.13.2 Prebuilt Components for MSVC 2017 64-bit" is sufficient. For ARM64 you need the matching ARM64 build of Qt or a custom compiled version. Later steps assume you install it in c:\Qt
 4.  Get rclone-browser source code. You either need to install git and clone it or download zip file from [releases][3]
 5.  Go to source folder `cd RcloneBrowser`
 6.  From cmd create new build folder  - `mkdir build` and then `cd build`
-7.  run `cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=c:\Qt\5.13.2\msvc2017_64 .. && cmake --build . --config Release`
-8.  run `c:\Qt\5.13.2\msvc2017_64\bin\windeployqt.exe --no-translations --no-angle --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"`
+7.  run `cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=c:\Qt\5.13.2\msvc2017_64 .. && cmake --build . --config Release` for x64 or replace `-A x64` and the prefix path with the ARM64 equivalents to build for Windows on ARM
+8.  run `c:\Qt\5.13.2\msvc2017_64\bin\windeployqt.exe --no-translations --no-angle --no-compiler-runtime --no-svg ".\build\Release\RcloneBrowser.exe"` (use the ARM64 version when targeting Windows on ARM)
 9.  build\Release folder contains now RcloneBrowser.exe binary and all other files required to run it
 10. If your system does not have required MSVC runtime you can install one from Microsoft [website](https://support.microsoft.com/en-gb/help/2977003/the-latest-supported-visual-c-downloads).
 

--- a/scripts/release_windows.cmd
+++ b/scripts/release_windows.cmd
@@ -2,23 +2,29 @@
 setlocal enabledelayedexpansion
 
 if "%1" == "" (
-  echo Please specify x86 ^(32-bit^) or x64 ^(64-bit^) architecture in cmdline
+  echo Please specify x86 ^(32-bit^), x64 ^(64-bit^) or arm64 architecture in cmdline
   goto :eof
 )
 
 set BOTH=0
-if not "%1" == "x86" if not "%1" == "x64" set BOTH=1
+if not "%1" == "x86" if not "%1" == "x64" if not "%1" == "arm64" set BOTH=1
 
 if %BOTH% == 1  (
-  echo Only x86 ^(32-bit^) or x64 ^(64-bit^) architectures are supported!
+  echo Only x86 ^(32-bit^), x64 ^(64-bit^) or arm64 architectures are supported!
   goto :eof
 )
 
 set ARCH=%1
-call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %ARCH%
+if "%ARCH%" == "arm64" (
+  call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x64_arm64
+) else (
+  call "c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %ARCH%
+)
 
 if "%ARCH%" == "x86" (
 set QT=C:\Qt\5.13.2\msvc2017\
+) else if "%ARCH%" == "arm64" (
+set QT=C:\Qt\5.13.2\msvc2017_arm64\
 ) else (
 set QT=C:\Qt\5.13.2\msvc2017_64\
 )
@@ -41,6 +47,9 @@ if "%ERRORLEVEL%" equ "0" (
 if "%ARCH%" == "x86" (
   set TARGET="%~dp0\..\release\rclone-browser-%VERSION_COMMIT%-windows-32-bit"
   set TARGET_EXE="%~dp0\..\release\rclone-browser-%VERSION_COMMIT%-windows-32-bit"
+) else if "%ARCH%" == "arm64" (
+  set TARGET="%~dp0\..\release\rclone-browser-%VERSION_COMMIT%-windows-arm64"
+  set TARGET_EXE="%~dp0\..\release\rclone-browser-%VERSION_COMMIT%-windows-arm64"
 ) else (
   set TARGET="%~dp0\..\release\rclone-browser-%VERSION_COMMIT%-windows-64-bit"
   set TARGET_EXE="%~dp0\..\release\rclone-browser-%VERSION_COMMIT%-windows-64-bit"
@@ -60,9 +69,11 @@ cd build
 
 if "%ARCH%" == "x86" (
 cmake -G %CMAKEGEN% -A Win32 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=%QT% ..
+) else if "%ARCH%" == "arm64" (
+cmake -G %CMAKEGEN% -A arm64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=%QT% ..
 ) else (
 cmake -G %CMAKEGEN% -A x64 -DCMAKE_CONFIGURATION_TYPES="Release" -DCMAKE_PREFIX_PATH=%QT% ..
-)
+) 
 
 cmake --build . --config Release
 popd
@@ -105,6 +116,8 @@ rem 64bits ;AppId={{0AF9BF43-8D44-4AFF-AE60-6CECF1BF0D31}
 rem 32bits ;AppId={{5644ED3A-6028-47C0-9796-29548EF7CEA3}
 if "%ARCH%" == "x86" (
 "c:\Program Files (x86)\Inno Setup 6"\iscc "/dMyAppVersion=%VERSION%" "/dMyAppId={{5644ED3A-6028-47C0-9796-29548EF7CEA3}" "/dMyAppDir=rclone-browser-%VERSION_COMMIT%-windows-32-bit" "/dMyAppArch=x86" /O"../release" /F"rclone-browser-%VERSION_COMMIT%-windows-32-bit" rclone-browser-win-installer.iss
+) else if "%ARCH%" == "arm64" (
+"c:\Program Files (x86)\Inno Setup 6"\iscc "/dMyAppVersion=%VERSION%" "/dMyAppId={{0AF9BF43-8D44-4AFF-AE60-6CECF1BF0D31}" "/dMyAppDir=rclone-browser-%VERSION_COMMIT%-windows-arm64" "/dMyAppArch=arm64" /O"../release" /F"rclone-browser-%VERSION_COMMIT%-windows-arm64" rclone-browser-win-installer.iss
 ) else (
 "c:\Program Files (x86)\Inno Setup 6"\iscc "/dMyAppVersion=%VERSION%" "/dMyAppId={{0AF9BF43-8D44-4AFF-AE60-6CECF1BF0D31}" "/dMyAppDir=rclone-browser-%VERSION_COMMIT%-windows-64-bit" "/dMyAppArch=x64" /O"../release" /F"rclone-browser-%VERSION_COMMIT%-windows-64-bit" rclone-browser-win-installer.iss
 )


### PR DESCRIPTION
## Summary
- document how to build on Windows ARM64 in README
- extend `release_windows.cmd` to handle `arm64` builds

## Testing
- `cmake ..` *(fails: Could not find Qt5Widgets)*

------
https://chatgpt.com/codex/tasks/task_e_684da9e3788c8327a6484cc27bc0f501